### PR TITLE
Add JavaDoc to public methods, add 100% branch coverage requirement,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <jackson-databind-version>2.9.1</jackson-databind-version>
         <jackson-dataformat-yaml-version>2.9.1</jackson-dataformat-yaml-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
-        <jacoco-percentage-instruction>1.0</jacoco-percentage-instruction>
+        <jacoco-percentage>1.0</jacoco-percentage>
         <junit-version>4.12</junit-version>
         <log4j-core-version>2.9.1</log4j-core-version>
         <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
@@ -173,7 +173,12 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>${jacoco-percentage-instruction}</minimum>
+                                            <minimum>${jacoco-percentage}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco-percentage}</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/java/com/expedia/www/haystack/metrics/appenders/log4j/EmitToGraphiteLog4jAppender.java
+++ b/src/main/java/com/expedia/www/haystack/metrics/appenders/log4j/EmitToGraphiteLog4jAppender.java
@@ -22,6 +22,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.apache.logging.log4j.Level.ERROR;
 import static org.apache.logging.log4j.Level.FATAL;
 
+/**
+ * A log4j2 appender that sends an error count to a graphite endpoint.
+ */
 @Plugin(name = "EmitToGraphiteLog4jAppender", category = "Core", elementType = "appender")
 public class EmitToGraphiteLog4jAppender extends AbstractAppender {
     @VisibleForTesting
@@ -42,9 +45,8 @@ public class EmitToGraphiteLog4jAppender extends AbstractAppender {
         super(name, null, null);
     }
 
-    @SuppressWarnings("WeakerAccess")
     @PluginFactory
-    public static EmitToGraphiteLog4jAppender createAppender(
+    static EmitToGraphiteLog4jAppender createAppender(
             @PluginAttribute(value = "name", defaultString = "EmitToGraphiteLog4jAppender") String name,
             @PluginAttribute(value = "address", defaultString = "haystack.local") String address,
             @PluginAttribute(value = "port", defaultInt = 2003) int port,
@@ -64,6 +66,12 @@ public class EmitToGraphiteLog4jAppender extends AbstractAppender {
         }
     }
 
+    /**
+     * Counts a log event if and only if it is an ERROR or a FATAL.
+     * @param logEvent the log event; if logEvent.getSource() returns null (as its JavaDoc says it can), then an error
+     *                 will be logged, otherwise Servo counter that identifies the source of the error will be
+     *                 incremented.
+     */
     @Override
     public void append(LogEvent logEvent) {
         final Level level = logEvent.getLevel();

--- a/src/test/java/com/expedia/www/haystack/metrics/appenders/log4j/EmitToGraphiteLog4jAppenderTest.java
+++ b/src/test/java/com/expedia/www/haystack/metrics/appenders/log4j/EmitToGraphiteLog4jAppenderTest.java
@@ -26,6 +26,7 @@ import static com.expedia.www.haystack.metrics.appenders.log4j.EmitToGraphiteLog
 import static com.expedia.www.haystack.metrics.appenders.log4j.EmitToGraphiteLog4jAppender.NULL_STACK_TRACE_ELEMENT_MSG;
 import static com.expedia.www.haystack.metrics.appenders.log4j.EmitToGraphiteLog4jAppender.SUBSYSTEM;
 import static org.apache.logging.log4j.Level.ERROR;
+import static org.apache.logging.log4j.Level.FATAL;
 import static org.apache.logging.log4j.Level.WARN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -169,7 +170,7 @@ public class EmitToGraphiteLog4jAppenderTest {
 
     @Test
     public void testIsLevelSevereEnoughToCount() {
-        final Set<Level> levelsThatAreSevereEnoughToCount = Sets.newHashSet(ERROR, Level.FATAL);
+        final Set<Level> levelsThatAreSevereEnoughToCount = Sets.newHashSet(ERROR, FATAL);
         final Level[] levels = Level.values();
         for(final Level level : levels) {
             assertEquals(levelsThatAreSevereEnoughToCount.contains(level),


### PR DESCRIPTION
make a plugin method package private instead of public so that it
doesn't show up in the JavaDoc.