### PR TITLE
Upgraded from 2.9.1 to 2.10.0; also made the versions of

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 0.1.6 / 2018-01-25 Upgrade the version of log4j2
+Upgraded from 2.9.1 to 2.10.0; also made the versions of jackson-databind and jackson-dataformat-yaml always match.
+
 ## 0.1.5 / 2018-01-10 Use new haystack-metrics API for error counter
 so that the individual applications' error metrics can be identified as specific to each application
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,12 +78,11 @@
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
         <haystack-metrics-version>0.5.0</haystack-metrics-version>
         <java.version>1.8</java.version>
-        <jackson-databind-version>2.9.1</jackson-databind-version>
-        <jackson-dataformat-yaml-version>2.9.1</jackson-dataformat-yaml-version>
+        <jackson-version>2.9.1</jackson-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>
         <jacoco-percentage>1.0</jacoco-percentage>
         <junit-version>4.12</junit-version>
-        <log4j-core-version>2.9.1</log4j-core-version>
+        <log4j-core-version>2.10.0</log4j-core-version>
         <maven-compiler-plugin-version>3.6.1</maven-compiler-plugin-version>
         <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
         <maven-javadoc-plugin-version>2.10.4</maven-javadoc-plugin-version>
@@ -139,14 +138,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind-version}</version>
+            <version>${jackson-version}</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson-dataformat-yaml-version}</version>
+            <version>${jackson-version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
jackson-databind and jackson-dataformat-yaml always match.