### PR TITLE
Upgrade haystack-metrics to 0.8.0 to pick up the code that doesn't shut

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.1.11 / 2018-03-05 Use new haystack-metrics 0.8.0
+This new version of haystack-metrics counts that number of times that the metrics polling thread was started, so that it
+can avoid shutting down that thread prematurely. This change was necessitated by the behavior of log4js when starting
+up.
+
 ## 0.1.10 / 2018-03-05 Use log4j2 lifecycle properly
 The factory method that creates the appender was starting the metrics polling thread, which is incorrect; as a result of
 this bug, the start up metric was never active for long, as log4j stops and then restarts the appender during start-up.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.expedia.www</groupId>
     <artifactId>haystack-log4j-metrics-appender</artifactId>
-    <version>0.1.10-SNAPSHOT</version>
+    <version>0.1.11-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <scm>
@@ -76,7 +76,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <coveralls-maven-plugin-version>4.3.0</coveralls-maven-plugin-version>
-        <haystack-metrics-version>0.8.0</haystack-metrics-version>
+        <haystack-metrics-version>0.9.0</haystack-metrics-version>
         <java.version>1.8</java.version>
         <jackson-version>2.9.1</jackson-version>
         <jacoco-maven-plugin-version>0.7.9</jacoco-maven-plugin-version>


### PR DESCRIPTION
down the polling thread until the last user of the thread shuts down.